### PR TITLE
Added basic searching capability

### DIFF
--- a/lib/Widgets/marker_list_page.dart
+++ b/lib/Widgets/marker_list_page.dart
@@ -5,15 +5,14 @@ import 'package:flutter/material.dart';
 import '../src/locations.dart' as locs;
 
 class MarkerListPage extends StatefulWidget {
-  //const MarkerListPage({Key? key}) : super(key: key)
   MarkerListPage({Key? key}) : super(key: key);
-  GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey();
 
   @override
   State<MarkerListPage> createState() => _MarkerListPageState();
 }
 
 class _MarkerListPageState extends State<MarkerListPage> {
+  String text = "";
   GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey();
 
   @override
@@ -42,6 +41,4 @@ class _MarkerListPageState extends State<MarkerListPage> {
       bottomNavigationBar: BottomNavBar(scaffoldKey: _scaffoldKey,),
     );
   }
-
-
 }

--- a/lib/Widgets/search_results.dart
+++ b/lib/Widgets/search_results.dart
@@ -1,0 +1,68 @@
+import 'package:capi_stonsker/Widgets/side_menu.dart';
+import 'package:capi_stonsker/nav/bottom_nav_bar.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import '../src/locations.dart' as locs;
+
+class SearchResultsPage extends StatefulWidget {
+  SearchResultsPage({Key? key}) : super(key: key);
+
+  @override
+  State<SearchResultsPage> createState() => _SearchResultsPageState();
+}
+
+class _SearchResultsPageState extends State<SearchResultsPage> {
+  String text = "";
+  GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    //String text = "";
+    return Scaffold(
+      key: _scaffoldKey,
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        leading: new IconButton(
+            icon: const Icon(Icons.arrow_back),
+            color: Colors.white,
+            onPressed: () {
+              Navigator.of(context).pop();
+            }
+        ),
+        title: Container(
+          width: MediaQuery.of(context).size.width,
+          height: 40,
+          decoration: BoxDecoration(
+              color: Colors.white, borderRadius: BorderRadius.circular(5)),
+          child: Center(
+            child: TextField(
+              onChanged: (value) async {
+                text = value;
+              },
+              decoration: InputDecoration(
+                prefixIcon: Icon(Icons.search),
+                suffixIcon: IconButton(
+                  icon: Icon(Icons.clear),
+                  onPressed: () {
+                    // clear search text
+                  },
+                ),
+                hintText: 'Search...',
+                border: InputBorder.none,
+              ),
+            ),
+          ),
+        ),
+        backgroundColor: Colors.blueGrey,
+      ),
+      body: locs.buildSearch(context, text),//returnText(text)),
+      drawer: SideMenu(),
+      bottomNavigationBar: BottomNavBar(scaffoldKey: _scaffoldKey,),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,14 @@
 import 'package:firebase_core/firebase_core.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
 import '/Widgets/map_page.dart';
 import '/Widgets/side_menu.dart';
 import '/src/locations.dart' as locs;
+import 'Widgets/full_info.dart';
+import 'Widgets/search_results.dart';
 import 'nav/bottom_nav_bar.dart';
+import '../src/marker.dart';
 
 void main() async {
   //Ensures Firebase connection initialized
@@ -52,6 +56,9 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
+    //String search_val = "";
+    //String searchKey;
+    //Stream streamQuery;
     return Scaffold(
       key: _scaffoldKey,
       appBar: AppBar(
@@ -61,23 +68,51 @@ class _MyHomePageState extends State<MyHomePage> {
           width: MediaQuery.of(context).size.width,
           height: 40,
           decoration: BoxDecoration(
-            color: Colors.white, borderRadius: BorderRadius.circular(5)),
-          child: Center(
-            key: search_bar,
-            child: TextField(
-              decoration: InputDecoration(
-                prefixIcon: Icon(Icons.search),
-                suffixIcon: IconButton(
-                  icon: Icon(Icons.clear),
-                  onPressed: () {
-                    /* Clear the search field */
-                  },
+            color: Colors.white, borderRadius: BorderRadius.circular(5),
+          ),
+          //child: Center(
+            //key: search_bar,
+            child: FractionallySizedBox(
+              //widthFactor: 0.9, // means 100%, you can change this to 0.8 (80%)
+              child: RaisedButton.icon(
+                onPressed: () {
+                  Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => SearchResultsPage()
+                      )
+                  );
+                },
+                color: Colors.white,
+                label: Text(
+                    "Search for a marker by name...",
+                    style: TextStyle(color: Colors.grey)
                 ),
-                hintText: 'Search...',
-                border: InputBorder.none
+                icon: Icon(Icons.search, color: Colors.grey),
               ),
             ),
-          ),
+            // child: TextField(
+            //   onChanged: (value) {
+            //     Navigator.push(
+            //         context,
+            //         MaterialPageRoute(
+            //           builder: (context) => SearchResultsPage()
+            //         )
+            //     );
+            //   },
+            //   decoration: InputDecoration(
+            //     prefixIcon: Icon(Icons.search),
+            //     suffixIcon: IconButton(
+            //       icon: Icon(Icons.clear),
+            //       onPressed: () {
+            //         /* Clear the search field */
+            //       },
+            //     ),
+            //     hintText: 'Search...',
+            //     border: InputBorder.none,
+            //   ),
+            // ),
+          //),
         ),
       ),
 
@@ -86,7 +121,8 @@ class _MyHomePageState extends State<MyHomePage> {
           Container(
               height: MediaQuery.of(context).size.height,
               width: MediaQuery.of(context).size.width,
-              child: MapPage()),
+              child: MapPage()
+          ),
         ],
       ),
 

--- a/lib/src/locations.dart
+++ b/lib/src/locations.dart
@@ -203,3 +203,34 @@ Widget _buildRow(BuildContext context, Marker m, double d) {
       },
   );
 }
+
+Widget buildSearch(BuildContext context, searchString) {
+  List<Marker> pass = List<Marker>.empty();
+  calcDist();
+  pass = markers.where((s) => s.name.toLowerCase().contains(searchString.toLowerCase())).toList();
+  pass.sort((a,b) { return a.userDist.compareTo(b.userDist); });
+
+  return ListView(
+    children: pass.map((m) {
+      return _buildSearch(context, m, m.userDist);
+    }).toList(),
+  );
+}
+
+Widget _buildSearch(BuildContext context, Marker m, double d) {
+  return ListTile(
+    title: Text(m.name),
+    //if userDist is default then display county instead of distance
+    subtitle: d == 0.0 ? Text(m.county) : Text(d.toStringAsFixed(2) + " mi."),
+    onTap: () {
+      Navigator.push(
+          context,
+          MaterialPageRoute(
+              builder: (context) => FullInfoPage(
+                sentMarker: m,
+              )
+          )
+      );
+    },
+  );
+}


### PR DESCRIPTION
I added the capability to search for markers by name (partial or full matches, not case sensitive) from Firebase; markers are displayed in order of their distance from the user. This is implemented from the home page by navigating to a search page that is initially populated with all of the markers in order of distance, then is shortened as the user types.

Shortcomings: user must press enter for the list to reload; I have not added a search bar to marker list page yet; UI/ transition from home page to search page is slow

Resolves #170 