### PR TITLE
shrink main map so move to current loc button is visible

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,7 +76,7 @@ class _MyHomePageState extends State<MyHomePage> {
     //String searchKey;
     //Stream streamQuery;
     return Scaffold(
-      extendBody: true,
+      // extendBody: true, TODO change position of move to current loc button
       key: _scaffoldKey,
       appBar: AppBar(
         automaticallyImplyLeading: false,


### PR DESCRIPTION
Resolves #206 

Currently, the map is set to extend behind the bottom navigation buttons on the home page. However, the marker list view button is obscuring the move to current location button on the map, so this small fix will temporarily shorten the map so all functionality is available. I will continue working on moving the move to current location button so we can re-expand the map behind the nav buttons