### PR TITLE
Fixes filtering bug

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -212,7 +212,7 @@ class _MyHomePageState extends State<MyHomePage> {
               height: MediaQuery.of(context).size.height,
               width: MediaQuery.of(context).size.width,
               child: MapPage(
-                  key: ValueKey<int>(selectedList),
+                  //key: ValueKey<int>(selectedList),
                   list: selectedList,
                   counties: selectedCounties,
                   searchText: searchText,


### PR DESCRIPTION
New key every time for filtering type causes LateInitializationError because the state is already initialized. Key not used for anything as far as I can tell.
Closes #298 